### PR TITLE
Gulp and Karma mods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,10 @@ bower_components
 # Built files - remove when minified
 dist
 
+# Logs
+sauce_connect.log
+
 # Editors
 *.swp
+\#.*\#
+.\#*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_script:
   - npm -g install bower gulp
   - bower install
   - gulp build
+script:
+  - gulp test
+  - gulp test-min

--- a/README.md
+++ b/README.md
@@ -261,20 +261,39 @@ $ gulp build          # builds front end dependencies into distributable js
 Note: You may need to use sudo to install globally with `npm`.
 
 ### Testing
-In order to run tests simply execute:
+Locally, testing uses Gulp, Karma and PhantomJS. To run tests:
 
 ```
-$ npm test
+$ gulp test
 ```
 
-You will need to have [PhantomJS](http://phantomjs.org/) installed for the
-tests to work out the box. If you don't want to install it you can modify
-`karma.conf` to run against different browsers locally.
+During development, you may wish for changed files to be watched so you the
+tests re-run automatically on change. To have Karma watch, use the default Gulp
+task:
 
-Locally, karma will run in watch mode, watching files for changes and
-automatically re-running the tests when necessary. When doing this, it is also
-necessary to run `gulp watch` to ensure the built file is up to date before
-testing.
+```
+gulp
+```
+
+This actually has Gulp watching for changes in `./src` and `./lib` and will
+rebuild `./dist/sdk.js` on changes. Karma then watches for changes in `./dist`
+and `./test` and will re-run tests whenever one of those changes.
+
+To run your local code against the same Sauce Labs browsers as Travis will run
+it against when it is merged, obtain your Sauce Labs username `${USERNAME}` and
+access key `${ACCESS_KEY}` and use:
+
+```
+export SAUCE_USERNAME="${USERNAME}"
+export SAUCE_ACCESS_KEY="${ACCESS_KEY}"
+TEST_ON_SAUCE=1 gulp test
+```
+
+The two exports set your Sauce Labs credentials, and the final line tells
+Karma (run by Gulp) to run the tests against Sauce Labs rather than PhantomJS.
+
+Change any above occurrence of `gulp test` to `gulp test-min` in order to test
+your minified code, to ensure minification has not introduced any breakages.
 
 ### Building
 In order to build the JS file use the following:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Note: You may need to use sudo to install globally with `npm`.
 Locally, testing uses Gulp, Karma and PhantomJS. To run tests:
 
 ```
-$ gulp test
+$ npm test
 ```
 
 During development, you may wish for changed files to be watched so the tests

--- a/README.md
+++ b/README.md
@@ -267,9 +267,8 @@ Locally, testing uses Gulp, Karma and PhantomJS. To run tests:
 $ gulp test
 ```
 
-During development, you may wish for changed files to be watched so you the
-tests re-run automatically on change. To have Karma watch, use the default Gulp
-task:
+During development, you may wish for changed files to be watched so the tests
+re-run automatically on change. To have Karma watch, use the default Gulp task:
 
 ```
 gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,14 @@ var inject = require('gulp-inject');
 var karma = require('karma').server;
 var rename = require('gulp-rename');
 var uglify = require('gulp-uglify');
+var del = require('del');
+
+/**
+ * Clean up the dist folder.
+ */
+gulp.task('clean', function () {
+    del(['./dist/*']);
+});
 
 /**
  * Build distributable JS file by injecting extra libraries.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var inject = require('gulp-inject');
 var karma = require('karma').server;
+var rename = require('gulp-rename');
 var uglify = require('gulp-uglify');
 
 /**
@@ -45,10 +46,11 @@ gulp.task('watch', function () {
 /**
  * Minify the compiled JS.
  */
-gulp.task('uglify', function () {
-    gulp.src('./dist/sdk.js')
-        .pipe(uglify())
-        .pipe(gulp.dest('./dist/'));
+gulp.task('uglify', ['build'], function () {
+    return gulp.src('./dist/sdk.js')
+               .pipe(uglify())
+               .pipe(rename('sdk.min.js'))
+               .pipe(gulp.dest('./dist'));
 });
 gulp.task('minify', ['uglify']); // alias
 
@@ -58,6 +60,19 @@ gulp.task('minify', ['uglify']); // alias
 gulp.task('test', function (done) {
     karma.start({
         configFile: __dirname + '/karma.conf.js'
+    }, done);
+});
+
+gulp.task('test-minified-file', ['uglify'], function (done) {
+    // This isn't pleasant.
+    var files = [
+        './dist/sdk.min.js',
+        './test/*.js'
+    ];
+
+    karma.start({
+        configFile: __dirname + '/karma.conf.js',
+        files: files
     }, done);
 });
 
@@ -73,4 +88,4 @@ gulp.task('karma-bg', function (done) {
 });
 
 gulp.task('default', ['karma-bg', 'watch']);
-gulp.task('test-min', ['uglify', 'test']);
+gulp.task('test-min', ['uglify', 'test-minified-file']);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      './dist/*.js',
+      './dist/sdk.js',
       './test/*.js'
     ],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,12 +2,15 @@
 // Generated on Mon Mar 16 2015 11:11:15 GMT+0000 (GMT)
 
 module.exports = function(config) {
-  // Require Sauce credentials on Travis
-  if (process.env.TRAVIS) {
-    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
-      console.log('SauceLabs credentials are needed for Travis tests.');
-      process.exit(1);
-    }
+  // Decide whether to run the tests on Sauce Labs, or fall back to using
+  // PhantomJS. Default to PhanomJS (TEST_ON_SAUCE=false).
+  var TEST_ON_SAUCE = false;
+
+  // Allows us to force a remote test on Sauce Labs by exporting TEST_ON_SAUCE.
+  // Also tells Travis to use Sauce Labs if the current test is not for a PR.
+  // See: http://docs.travis-ci.com/user/pull-requests/
+  if (process.env.TEST_ON_SAUCE || process.env.TRAVIS_PULL_REQUEST == 'false') {
+    TEST_ON_SAUCE = true;
   }
 
   var conf = {
@@ -61,7 +64,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: false,
 
 
     // start these browsers
@@ -71,14 +74,17 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: true
   };
 
-  // Set up Sauce Labs config when running on Travis
-  if (process.env.TRAVIS) {
-    conf.reporters = ['spec', 'saucelabs'];
-    conf.autoWatch = false;
-    conf.singleRun = true;
+  // Augment config for Sauce Labs
+  if (TEST_ON_SAUCE) {
+    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+      console.log('Sauce Labs credentials are needed for Sauce Labs tests.');
+      process.exit(1);
+    }
+
+    conf.reporters.push('saucelabs');
     conf.captureTimeout = 120000;
 
     conf.browsers = Object.keys(browsers);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@
 
 module.exports = function(config) {
   // Decide whether to run the tests on Sauce Labs, or fall back to using
-  // PhantomJS. Default to PhanomJS (TEST_ON_SAUCE=false).
+  // PhantomJS. Default to PhantomJS (TEST_ON_SAUCE=false).
   var TEST_ON_SAUCE = false;
 
   // Allows us to force a remote test on Sauce Labs by exporting TEST_ON_SAUCE.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "devDependencies": {
+    "del": "^1.1.1",
     "expect.js": "0.3.1",
     "gulp": "3.8.11",
     "gulp-inject": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/digitalanimal.com/advocate-things-js-sdk/issues"
   },
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start karma.conf.js"
+    "test": "./node_modules/gulp/bin/gulp.js test"
   },
   "devDependencies": {
     "del": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "test": "./node_modules/gulp/bin/gulp.js test"
   },
   "devDependencies": {
-    "del": "^1.1.1",
+    "del": "1.1.1",
     "expect.js": "0.3.1",
     "gulp": "3.8.11",
     "gulp-inject": "1.2.0",
-    "gulp-rename": "^1.2.2",
+    "gulp-rename": "1.2.2",
     "gulp-uglify": "1.1.0",
     "karma": "0.12.31",
     "karma-browserify": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "expect.js": "0.3.1",
     "gulp": "3.8.11",
     "gulp-inject": "1.2.0",
+    "gulp-rename": "^1.2.2",
     "gulp-uglify": "1.1.0",
     "karma": "0.12.31",
     "karma-browserify": "4.1.2",


### PR DESCRIPTION
Rewritten Karma config to be less reliant on Travis etc., but to enable it to run tests on Phantom when testing a pull request (no permissions for fork PRs, see: http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests).

Gulpfile updated to include some useful dev tasks:
* test - run the tests against phantom/sauce
* watch test (default) - watch files and run tests on change
* test-min - uglify code and run tests against it to ensure uglification does not break JS