### PR TITLE
handle no sharepoint token and no query param name

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -377,8 +377,8 @@
             if (/^20[0-9]{1}/.test(xhr.status)) {
                 var res = JSON.parse(xhr.responseText);
 
+                var queryParamName = res[0].queryParamName;
                 currentSharepointToken = getTokenOrAlias(res[0]);
-                queryParamName = res[0].queryParamName;
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);
@@ -501,8 +501,8 @@
                 var res = JSON.parse(xhr.responseText);
 
                 var oldToken = currentSharepointToken;
+                var queryParamName = res[0].queryParamName;
                 currentSharepointToken = getTokenOrAlias(res[0]);
-                queryParamName = res[0].queryParamName;
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -15,7 +15,6 @@
     }).call(utils);
 
     // Don't hard code anything
-    var queryParamName = null; // this is now set in the DB
     var scriptTagId = 'advocate-things-script';
     var storageName = 'advocate-things';
 
@@ -94,6 +93,17 @@
 
         return tokens;
     }
+
+    /**
+     * Helper function to retrieve either the alias or token from some Sharepoint
+     * data with alias taking precedence.
+     * @param {object} sharepointData - a single sharepoint data object (usually res[0])
+     * @return {string} - the share token to use
+     */
+    function getTokenOrAlias(sharepointData) {
+        return sharepointData.alias || sharepointData.token || null;
+    }
+
 
     /**
      * Initialises the event listener array with empty arrays to contain
@@ -216,9 +226,9 @@
      * TODO: Clean up multiple occurences of DA= query params.
      * @param {string} token - The sharepoint token to insert into the URL.
      */
-    function urlAppendToken(token) {
+    function urlAppendToken(token, queryParamName) {
         console.info('urlAppendToken()');
-        if (!token) {
+        if (!token || !queryParamName) {
             return;
         }
 
@@ -367,14 +377,14 @@
             if (/^20[0-9]{1}/.test(xhr.status)) {
                 var res = JSON.parse(xhr.responseText);
 
-                currentSharepointToken = res[0].token;
+                currentSharepointToken = getTokenOrAlias(res[0]);
                 queryParamName = res[0].queryParamName;
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);
 
-                // Append token to URL (blindly in this instance)
-                urlAppendToken(currentSharepointToken);
+                // Try to append token to URL
+                urlAppendToken(currentSharepointToken, queryParamName);
 
                 // Callback
                 if (cb) {
@@ -491,18 +501,19 @@
                 var res = JSON.parse(xhr.responseText);
 
                 var oldToken = currentSharepointToken;
-                currentSharepointToken = res[0].token;
+                currentSharepointToken = getTokenOrAlias(res[0]);
                 queryParamName = res[0].queryParamName;
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);
 
-                // Append token to URL (conditionally this time)
+                // Conditionally append token to URL
                 if (currentSharepointToken === oldToken) {
                     // Request new token
                     sendSharepointInit(data); // pre-named data object
                 } else {
-                    urlAppendToken(currentSharepointToken);
+                    // Try to append token to URL
+                    urlAppendToken(currentSharepointToken, queryParamName);
                 }
 
                 // Callback


### PR DESCRIPTION
Fixes #23 and #31 

#23 addresses the former crash when no share token was returned (BG advo switched off)
#31 addresses the preference of using a share alias over the token when one is present