### PR TITLE
make spc response handling more robust

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -206,13 +206,16 @@
         d._at.fingerprint = new utils.Fingerprint().get().toString();
         d._at.url = document.location.href;
 
-        d._client = {};
-        Object.keys(d).forEach(function (key) {
-            if (!(key === '_at' || key === '_client')) {
-                d._client[key] = d[key];
-                delete d[key];
-            }
-        });
+	// Don't re-tidy
+	if (!('_client' in d)) {
+            d._client = {};
+            Object.keys(d).forEach(function (key) {
+		if (!(key === '_at' || key === '_client')) {
+                    d._client[key] = d[key];
+                    delete d[key];
+		}
+            });
+	}
 
         return d;
     }
@@ -358,14 +361,14 @@
         if (d && d._at) {
             if (d._at.sharepointName) {
                 // sharepoint
-                sendSharepoint(d, cb);
+                sendSharepoint(d, cb); // FIXME: this is wrong (check method sig)
             } else if (d._at.touchpointName) {
                 // touchpoint
-                sendTouchpoint(d, cb);
+                sendTouchpoint(d, cb); // FIXME: this is wrong
             } else {
                 // both
                 sendTouchpoint(d, function () {
-                    sendSharepoint(d, cb);
+                    sendSharepoint(d, cb); // FIXME: this is wrong
                 });
             }
         }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -101,9 +101,20 @@
      * @return {string} - the share token to use
      */
     function getTokenOrAlias(sharepointData) {
-        return sharepointData.alias || sharepointData.token || null;
+	if (sharepointData) {
+            return sharepointData.alias || sharepointData.token || null;
+	}
+
+	return null;
     }
 
+    function getQueryParamName(sharepointData) {
+	if (sharepointData) {
+	    return sharepointData.queryParamName || null;
+	}
+
+	return null;
+    }
 
     /**
      * Initialises the event listener array with empty arrays to contain
@@ -377,8 +388,8 @@
             if (/^20[0-9]{1}/.test(xhr.status)) {
                 var res = JSON.parse(xhr.responseText);
 
-                var queryParamName = res[0].queryParamName;
-                currentSharepointToken = getTokenOrAlias(res[0]);
+                var queryParamName = getQueryParamName(res && res[0]);
+                currentSharepointToken = getTokenOrAlias(res && res[0]);
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);
@@ -501,8 +512,8 @@
                 var res = JSON.parse(xhr.responseText);
 
                 var oldToken = currentSharepointToken;
-                var queryParamName = res[0].queryParamName;
-                currentSharepointToken = getTokenOrAlias(res[0]);
+                var queryParamName = getQueryParamName(res && res[0]);
+                currentSharepointToken = getTokenOrAlias(res && res[0]);
 
                 // Trigger event
                 triggerEvent(events.SharepointSaved, res);


### PR DESCRIPTION
We should always receive an array at the very least from the spc. On the offchance that we don't, it handles null/undefined as well.