### PR TITLE
Replace removed conditions

### DIFF
--- a/src/sdk.js
+++ b/src/sdk.js
@@ -261,7 +261,7 @@
         var tidy; // Will contain tidied data.
 
         // Ensure data is a real object. Initialise if not.
-        if (Object.prototype.toString.call(data) !== '[object Object]') {
+        if (!data || Object.prototype.toString.call(data) !== '[object Object]') {
             tidy = {};
         } else {
             tidy = JSON.parse(JSON.stringify(data || {})); // clone data
@@ -269,7 +269,7 @@
 
         for (var propId in requiredProps) {
             if (requiredProps.hasOwnProperty(propId)) {
-                if (Object.prototype.toString.call(tidy[requiredProps[propId]]) !== '[object Object]') {
+                if (!tidy[requiredProps[propId]] || Object.prototype.toString.call(tidy[requiredProps[propId]]) !== '[object Object]') {
                     tidy[requiredProps[propId]] = {};
                 }
             }
@@ -309,7 +309,7 @@
         //   -> advocate-things JSON.stringified({}
         //      -> apiKey []
         //         -> data {})
-        if (Object.prototype.toString.call(data) !== '[object Object]' || !data.token) {
+        if (!data || Object.prototype.toString.call(data) !== '[object Object]' || !data.token) {
             return null;
         }
 


### PR DESCRIPTION
So, it turns out that in IE7 (at least) the following is true:

```js
Object.prototype.toString.call(null) => [object Object]
Object.prototype.toString.call(undefined) => [object Object]
```

Who'd have thought?!