### PR TITLE
Share token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ To reiterate the above, callbacks are run regardless of the success of the prece
 * [Sharepoint metadata](#api-metadata-sharepoint)
 * [Touchpoint metadata](#api-metadata-touchpoint)
 * [Events](#api-events)
-* [Other available data](#other-available-data)
+* [Convenience methods](#api-convenience)
+* [Other available data](#api-other-available-data)
 
 ### <a name="api-init"></a>`AT.init(config)`
 Initialises the SDK.
@@ -549,7 +550,16 @@ Six events are currently provided by the SDK.
 * `AT.Events.TouchRegistered` - triggered when a touch has successfully been saved. Metadata is [Touchpoint metadata](#api-metadata-touchpoint).
 * `AT.Events.ReferredPerson` - triggered when a touch has successfully been saved, which is reached via a share. Metadata is [Touchpoint metadata](#api-metadata-touchpoint).
 
-### Other available Data
+### <a name="api-convenience"></a>Convenience methods
+At present, two convenience methods are made available to allow for simpler use
+of this SDK.
+
+* `AT.getAddressBarShareToken()` - returns the share token that is currently
+in the address bar.
+* `AT.getDefaultToken()` - returns the default token for the current page, that
+  is, the first valid token for any Sharepoint present.
+
+### <a name="api-other-available-data"></a>Other available Data
 Some other data is made available in the `AT` namespace for use.
 
 * `AT.queryParamName` - set to the name of the query parameter as defined when setting up your Client.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ AT.init({
 
 See [`init`](#api-init) for all initialisation options.
 
+The following functions may be manually passed new data, or `window.advocate_things_data` may be updated and the functions called without data. That is, the contents of `window.advocate_things_data` is the default data that is sent with any request.
+
 To manually register touch data, use the [`registerTouch`](#api-registertouch) function:
 
 ```js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var buildLibs = [
   './bower_components/cookie/cookie.js',
   './lib/cookieStorage.js', // requires cookie.js
   './lib/localStorage.js',
+  './lib/sessionStorage.js',
   './bower_components/fingerprint/fingerprint.js'
 ];
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,7 @@ module.exports = function(config) {
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
             './test/**/*.js': ['browserify'],
+            './dist/sdk.js': ['coverage']
         },
 
 
@@ -47,7 +48,7 @@ module.exports = function(config) {
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
         // reporters: ['progress'],
-        reporters: ['spec'], // add 'saucelabs'
+        reporters: ['spec', 'coverage'], // add 'saucelabs'
 
 
         // web server port
@@ -106,62 +107,62 @@ module.exports = function(config) {
 };
 
 var browsers = {
-    // sl_chrome43_win7: {
-    //   base: 'SauceLabs',
-    //   browserName: 'chrome',
-    //   platform: 'Windows 7',
-    //   version: '43'
-    // },
-    // sl_chrome26_win7: {
-    //   base: 'SauceLabs',
-    //   browserName: 'chrome',
-    //   platform: 'Windows 7',
-    //   version: '26'
-    // },
-    // sl_firefox37: {
-    //     base: 'SauceLabs',
-    //     browserName: 'firefox',
-    //     platform: 'Windows 7',
-    //     version: '37.0'
-    // },
-    // sl_firefox4: {
-    //     base: 'SauceLabs',
-    //     browserName: 'firefox',
-    //     platform: 'Windows 7',
-    //     version: '4.0'
-    // },
-    // sl_ie11_win81: {
-    //     base: 'SauceLabs',
-    //     browserName: 'internet explorer',
-    //     platform: 'Windows 8.1',
-    //     version: '11.0'
-    // },
-    // sl_ie10_win7: {
-    //     base: 'SauceLabs',
-    //     browserName: 'internet explorer',
-    //     platform: 'Windows 7',
-    //     version: '10.0'
-    // },
+    sl_chrome43_win7: {
+      base: 'SauceLabs',
+      browserName: 'chrome',
+      platform: 'Windows 7',
+      version: '43'
+    },
+    sl_chrome26_win7: {
+      base: 'SauceLabs',
+      browserName: 'chrome',
+      platform: 'Windows 7',
+      version: '26'
+    },
+    sl_firefox37: {
+        base: 'SauceLabs',
+        browserName: 'firefox',
+        platform: 'Windows 7',
+        version: '37.0'
+    },
+    sl_firefox4: {
+        base: 'SauceLabs',
+        browserName: 'firefox',
+        platform: 'Windows 7',
+        version: '4.0'
+    },
+    sl_ie11_win81: {
+        base: 'SauceLabs',
+        browserName: 'internet explorer',
+        platform: 'Windows 8.1',
+        version: '11.0'
+    },
+    sl_ie10_win7: {
+        base: 'SauceLabs',
+        browserName: 'internet explorer',
+        platform: 'Windows 7',
+        version: '10.0'
+    },
     sl_ie7_winxp: {
         base: 'SauceLabs',
         browserName: 'internet explorer',
         platform: 'windows xp',
         version: '7.0'
-    }// ,
-    // sl_iphone_ios82: {
-    //     base: 'SauceLabs',
-    //     deviceName: 'iPhone Simulator',
-    //     "device-orientation": 'portrait',
-    //     browserName: 'safari',
-    //     platform: 'OS X 10.10',
-    //     version: '8.2'
-    // },
-    // sl_android_44: {
-    //     base: 'SauceLabs',
-    //     deviceName: 'Android Emulator',
-    //     browserName: 'android',
-    //     "device-orientation": 'portrait',
-    //     platform: 'Linux',
-    //     version: '4.4'
-    // }
+    },
+    sl_iphone_ios82: {
+        base: 'SauceLabs',
+        deviceName: 'iPhone Simulator',
+        "device-orientation": 'portrait',
+        browserName: 'safari',
+        platform: 'OS X 10.10',
+        version: '8.2'
+    },
+    sl_android_44: {
+        base: 'SauceLabs',
+        deviceName: 'Android Emulator',
+        browserName: 'android',
+        "device-orientation": 'portrait',
+        platform: 'Linux',
+        version: '4.4'
+    }
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -106,62 +106,62 @@ module.exports = function(config) {
 };
 
 var browsers = {
-    sl_chrome43_win7: {
-      base: 'SauceLabs',
-      browserName: 'chrome',
-      platform: 'Windows 7',
-      version: '43'
-    },
-    sl_chrome26_win7: {
-      base: 'SauceLabs',
-      browserName: 'chrome',
-      platform: 'Windows 7',
-      version: '26'
-    },
-    sl_firefox37: {
-        base: 'SauceLabs',
-        browserName: 'firefox',
-        platform: 'Windows 7',
-        version: '37.0'
-    },
-    sl_firefox4: {
-        base: 'SauceLabs',
-        browserName: 'firefox',
-        platform: 'Windows 7',
-        version: '4.0'
-    },
-    sl_ie11_win81: {
-        base: 'SauceLabs',
-        browserName: 'internet explorer',
-        platform: 'Windows 8.1',
-        version: '11.0'
-    },
-    sl_ie10_win7: {
-        base: 'SauceLabs',
-        browserName: 'internet explorer',
-        platform: 'Windows 7',
-        version: '10.0'
-    },
+    // sl_chrome43_win7: {
+    //   base: 'SauceLabs',
+    //   browserName: 'chrome',
+    //   platform: 'Windows 7',
+    //   version: '43'
+    // },
+    // sl_chrome26_win7: {
+    //   base: 'SauceLabs',
+    //   browserName: 'chrome',
+    //   platform: 'Windows 7',
+    //   version: '26'
+    // },
+    // sl_firefox37: {
+    //     base: 'SauceLabs',
+    //     browserName: 'firefox',
+    //     platform: 'Windows 7',
+    //     version: '37.0'
+    // },
+    // sl_firefox4: {
+    //     base: 'SauceLabs',
+    //     browserName: 'firefox',
+    //     platform: 'Windows 7',
+    //     version: '4.0'
+    // },
+    // sl_ie11_win81: {
+    //     base: 'SauceLabs',
+    //     browserName: 'internet explorer',
+    //     platform: 'Windows 8.1',
+    //     version: '11.0'
+    // },
+    // sl_ie10_win7: {
+    //     base: 'SauceLabs',
+    //     browserName: 'internet explorer',
+    //     platform: 'Windows 7',
+    //     version: '10.0'
+    // },
     sl_ie7_winxp: {
         base: 'SauceLabs',
         browserName: 'internet explorer',
         platform: 'windows xp',
         version: '7.0'
-    },
-    sl_iphone_ios82: {
-        base: 'SauceLabs',
-        deviceName: 'iPhone Simulator',
-        "device-orientation": 'portrait',
-        browserName: 'safari',
-        platform: 'OS X 10.10',
-        version: '8.2'
-    },
-    sl_android_44: {
-        base: 'SauceLabs',
-        deviceName: 'Android Emulator',
-        browserName: 'android',
-        "device-orientation": 'portrait',
-        platform: 'Linux',
-        version: '4.4'
-    }
+    }// ,
+    // sl_iphone_ios82: {
+    //     base: 'SauceLabs',
+    //     deviceName: 'iPhone Simulator',
+    //     "device-orientation": 'portrait',
+    //     browserName: 'safari',
+    //     platform: 'OS X 10.10',
+    //     version: '8.2'
+    // },
+    // sl_android_44: {
+    //     base: 'SauceLabs',
+    //     deviceName: 'Android Emulator',
+    //     browserName: 'android',
+    //     "device-orientation": 'portrait',
+    //     platform: 'Linux',
+    //     version: '4.4'
+    // }
 };

--- a/lib/sessionStorage.js
+++ b/lib/sessionStorage.js
@@ -1,5 +1,5 @@
 /**
- * Simple interface for localStorage to match cookies.
+ * Simple interface for sessionStorage to match cookies.
  */
 var sesStorage = {
     hasItem: function (key) {

--- a/lib/sessionStorage.js
+++ b/lib/sessionStorage.js
@@ -1,0 +1,19 @@
+/**
+ * Simple interface for localStorage to match cookies.
+ */
+var sesStorage = {
+    hasItem: function (key) {
+        return sessionStorage.hasOwnProperty(key);
+    },
+    getItem: function (key) {
+        return sessionStorage.getItem(key);
+    },
+    setItem: function (key, value) {
+        sessionStorage.setItem(key, value);
+    },
+    removeItem: function (key) {
+        sessionStorage.removeItem(key);
+    }
+};
+
+this.sesStorage = sesStorage;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Advocate Things SDK for JavaScript",
   "author": "Digital Animal",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/digitalanimal.com/advocate-things-js-sdk",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.3",
     "gulp-uglify": "1.1.0",
-    "karma": "0.12.31",
+    "karma": "0.12.37",
     "karma-browserify": "4.1.2",
     "karma-mocha": "0.1.10",
     "karma-phantomjs-launcher": "0.1.4",

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -161,7 +161,7 @@
             : params;
 
         // Rewrite the URL
-        History.replaceState(null, null, newParams);
+        History.replaceState(null, document.title, newParams);
     };
 
     /**

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -653,6 +653,21 @@
             token = null;
         }
 
+        if (typeof token === 'function') {
+            cb = token;
+            token = null;
+            data = null;
+        }
+
+        if (typeof data === 'function') {
+            cb = data;
+            data = null;
+        }
+
+        if (!data) {
+            data = window.advocate_things_data;
+        }
+
         if (!data) {
             if (cb) {
                 return cb(new Error('[updateToken] You must specify data to update with.'));

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -15,6 +15,7 @@
     var DEFAULT_QUERY_PARAM_NAME = 'AT';
     var SCRIPT_ID = 'advocate-things-script';
     var STORAGE_NAME = 'advocate-things';
+    var SESSION_STORAGE_NAME = 'advocate-things-session';
     var POINTS = {
         Sharepoint: {
             name: 'Sharepoint',
@@ -304,8 +305,8 @@
         }
 
         // Initialise if needed
-        if (!store.hasItem(STORAGE_NAME)) {
-            store.setItem(STORAGE_NAME, JSON.stringify({}), Infinity);
+        if (!store.hasItem(SESSION_STORAGE_NAME)) {
+            store.setItem(SESSION_STORAGE_NAME, JSON.stringify({}), Infinity);
         }
 
         return store;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -728,6 +728,18 @@
      */
     requireKey.lockToken = function (token, cb) {
         AT._log('info', 'lockToken()');
+
+        // Let's work out what's what
+        if (typeof token === 'function') {
+            cb = token;
+            token = null;
+        }
+
+        if (!token) {
+            // If no token defined, assume we want the first.
+            token = AT._getShareTokens()[0];
+        }
+
         if (!token) {
             if (cb) {
                 return cb(new Error('[lockToken] You must specify a token to lock.'));

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -591,22 +591,19 @@
     requireKey.createToken = function (name, data, cb) {
         AT._log('info', 'createToken()');
 
-        // Let's work out what's what
-        if (Object.prototype.toString.call(name) === '[object Object]' && name !== null) {
+        if (name && Object.prototype.toString.call(name) !== '[object String]') {
             cb = data;
             data = name;
             name = null;
         }
 
-        if (typeof name === 'function') {
-            cb = name;
-            name = null;
+        if (data && Object.prototype.toString.call(data) !== '[object Object]') {
+            cb = data;
             data = null;
         }
 
-        if (typeof data === 'function') {
-            cb = data;
-            data = null;
+        if (cb && Object.prototype.toString.call(cb) !== '[object Function]') {
+            cb = null;
         }
 
         var dataPrep = AT._prepareData(data || window[GLOBAL_DATA]);
@@ -663,22 +660,19 @@
     requireKey.updateToken = function (token, data, cb) {
         AT._log('info', 'updateToken()');
 
-        // Let's work out what's what
-        if (Object.prototype.toString.call(token) === '[object Object]' && token !== null) {
+        if (token && Object.prototype.toString.call(token) !== '[object String]') {
             cb = data;
             data = token;
             token = null;
         }
 
-        if (typeof token === 'function') {
-            cb = token;
-            token = null;
+        if (data && Object.prototype.toString.call(data) !== '[object Object]') {
+            cb = data;
             data = null;
         }
 
-        if (typeof data === 'function') {
-            cb = data;
-            data = null;
+        if (cb && Object.prototype.toString.call(cb) !== '[object Function]') {
+            cb = null;
         }
 
         // Firstly default to global data if no data provided.
@@ -749,10 +743,13 @@
     requireKey.lockToken = function (token, cb) {
         AT._log('info', 'lockToken()');
 
-        // Let's work out what's what
-        if (typeof token === 'function') {
+        if (token && Object.prototype.toString.call(token) !== '[object String]') {
             cb = token;
             token = null;
+        }
+
+        if (cb && Object.prototype.toString.call(cb) !== '[object Function]') {
+            cb = null;
         }
 
         if (!token) {
@@ -808,23 +805,21 @@
      * @param {function} [cb] - Callback function with (err, tokens).
      */
     requireKey.consumeToken = function (token, data, cb) {
-        // Let's work out what's what
+        AT._log('info', 'consumeToken()');
 
-        if (Object.prototype.toString.call(token) === '[object Object]' && token !== null) {
+        if (token && Object.prototype.toString.call(token) !== '[object String]') {
             cb = data;
             data = token;
             token = null;
         }
 
-        if (typeof token === 'function') {
-            cb = token;
-            token = null;
+        if (data && Object.prototype.toString.call(data) !== '[object Object]') {
+            cb = data;
             data = null;
         }
 
-        if (typeof data === 'function') {
-            cb = data;
-            data = null;
+        if (cb && Object.prototype.toString.call(cb) !== '[object Function]') {
+            cb = null;
         }
 
         // If no token defined, grab the default

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -594,7 +594,7 @@
         AT._log('info', 'createToken()');
 
         // Let's work out what's what
-        if (Object.prototype.toString.call(name) === '[object Object]') {
+        if (Object.prototype.toString.call(name) === '[object Object]' && name !== null) {
             cb = data;
             data = name;
             name = null;
@@ -666,7 +666,7 @@
         AT._log('info', 'updateToken()');
 
         // Let's work out what's what
-        if (Object.prototype.toString.call(token) === '[object Object]') {
+        if (Object.prototype.toString.call(token) === '[object Object]' && token !== null) {
             cb = data;
             data = token;
             token = null;
@@ -808,7 +808,8 @@
      */
     requireKey.consumeToken = function (token, data, cb) {
         // Let's work out what's what
-        if (Object.prototype.toString.call(token) === '[object Object]') {
+
+        if (Object.prototype.toString.call(token) === '[object Object]' && token !== null) {
             cb = data;
             data = token;
             token = null;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -8,6 +8,7 @@
     var sessionStore = null;
     var config = {};
     AT.shareToken = null;
+    AT.shareTokens = [];
     AT.queryParamName = null;
 
     // Constants

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -546,7 +546,7 @@
 
         xhr.onload = function () {
             // Handle error responses.
-            if (!/^200$/.test(xhr.status)) {
+            if (!/^20[0-9]{1}/.test(xhr.status)) {
                 if (cb) {
                     return cb(new Error(xhr.statusText));
                 }
@@ -559,7 +559,7 @@
 
             AT._storeTouchpointData(res);
 
-            var meta = JSON.parse(res.metadata);
+            var meta = res.metadata;
 
             // Trigger saved event
             AT._triggerEvent(AT.Events.TouchRegistered, meta);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -306,7 +306,7 @@
 
         // Initialise if needed
         if (!store.hasItem(SESSION_STORAGE_NAME)) {
-            store.setItem(SESSION_STORAGE_NAME, JSON.stringify({}), Infinity);
+            store.setItem(STORAGE_NAME, JSON.stringify({}), Infinity);
         }
 
         return store;
@@ -696,8 +696,8 @@
         }
 
         if (!token) {
-            // If no token defined, assume we want the first.
-            token = AT._getShareTokens()[0];
+            // If no token defined, grab the default
+            token = AT.getDefaultToken();
         }
 
         if (!token) {
@@ -755,8 +755,8 @@
         }
 
         if (!token) {
-            // If no token defined, assume we want the first.
-            token = AT._getShareTokens()[0];
+            // If no token defined, grab the default
+            token = AT.getDefaultToken();
         }
 
         if (!token) {
@@ -826,8 +826,8 @@
         }
 
         if (!token) {
-            // If no token defined, assume we want the first.
-            token = AT._getShareTokens()[0];
+            // If no token defined, grab the default.
+            token = AT.getDefaultToken();
         }
 
         if (!token) {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -86,6 +86,7 @@
      * Bower libraries: Cookie, Fingerprint, History
      */
     AT._utils = {};
+    /* istanbul ignore next */
     (function () {
         /* inject:utils */
         /* endinject:utils */

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -512,7 +512,25 @@
     requireKey.registerTouch = function (name, data, cb) {
         AT._log('info', 'registerTouch()');
 
-        var dataPrep = AT._prepareData(data);
+        // Let's work out what's what
+        if (Object.prototype.toString.call(name) === '[object Object]') {
+            cb = data;
+            data = name;
+            name = null;
+        }
+
+        if (typeof name === 'function') {
+            cb = name;
+            name = null;
+            data = null;
+        }
+
+        if (typeof data === 'function') {
+            cb = data;
+            data = null;
+        }
+
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
 
         if (name) {
             dataPrep._at.touchpointName = name;
@@ -572,7 +590,6 @@
         AT._log('info', 'createToken()');
 
         // Let's work out what's what
-        //if (typeof name === 'object') {
         if (Object.prototype.toString.call(name) === '[object Object]') {
             cb = data;
             data = name;
@@ -590,7 +607,7 @@
             data = null;
         }
 
-        var token;
+        var token; // TODO: is this used?
 
         var dataPrep = AT._prepareData(data || window.advocate_things_data);
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -434,7 +434,7 @@
 
         var tokens = [];
         for (var i=0, len=data.length; i<len; i++) {
-            if (Object.prototype.toString.call(data[i]) === '[object Object]' &&
+            if (data[i] && Object.prototype.toString.call(data[i]) === '[object Object]' &&
                 data[i].hasOwnProperty('token')) {
                 tokens.push(data[i].token);
             }
@@ -584,9 +584,9 @@
 
     /**
      * Obtain a new share token. Optionally initialise the token metadata.
-     * @param {string} name - The name of a sharepoint for which to generate a
+     * @param {string} [name] - The name of a sharepoint for which to generate a
      *                        token.
-     * @param {object} data - Data to initialise with.
+     * @param {object} [data] - Data to initialise with.
      * @param {function} [cb] - Callback function with (err, tokens).
      */
     requireKey.createToken = function (name, data, cb) {
@@ -738,7 +738,7 @@
     /**
      * Allows locking of a token, after which the metadata can no longer be
      * updated.
-     * @param {string} token - The token which should be locked.
+     * @param {string} [token] - The token which should be locked.
      * @param {function} [cb] - Callback function with (err, token).
      */
     requireKey.lockToken = function (token, cb) {
@@ -753,11 +753,12 @@
             cb = null;
         }
 
+        // If no token defined, grab the default
         if (!token) {
-            // If no token defined, grab the default
             token = AT.getDefaultToken();
         }
 
+        // Fail if no token or default token.
         if (!token) {
             if (cb) {
                 return cb(new Error('[lockToken] You must specify a token to lock.'));
@@ -801,8 +802,8 @@
      * Consumes a share token. This locks in the metadata for this token. Use
      * to signify that a share has/is about to happen (e.g. clicking share
      * button).
-     * @param {string} token - The token which should be consumed.
-     * @param {object} data - The data to finally augment previous data with.
+     * @param {string} [token] - The token which should be consumed.
+     * @param {object} [data] - The data to finally augment previous data with.
      * @param {function} [cb] - Callback function with (err, tokens).
      */
     requireKey.consumeToken = function (token, data, cb) {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -12,6 +12,7 @@
     AT.queryParamName = null;
 
     // Constants
+    var GLOBAL_DATA = 'advocate_things_data';
     var DEFAULT_QUERY_PARAM_NAME = 'AT';
     var SCRIPT_ID = 'advocate-things-script';
     var STORAGE_NAME = 'advocate-things';
@@ -534,7 +535,7 @@
             data = null;
         }
 
-        var dataPrep = AT._prepareData(data || window.advocate_things_data);
+        var dataPrep = AT._prepareData(data || window[GLOBAL_DATA]);
 
         if (name) {
             dataPrep._at.touchpointName = name;
@@ -611,7 +612,7 @@
             data = null;
         }
 
-        var dataPrep = AT._prepareData(data || window.advocate_things_data);
+        var dataPrep = AT._prepareData(data || window[GLOBAL_DATA]);
 
         if (name) {
             dataPrep._at.sharepointName = name;
@@ -684,7 +685,7 @@
         }
 
         if (!data) {
-            data = window.advocate_things_data;
+            data = window[GLOBAL_DATA];
         }
 
         if (!data) {
@@ -841,7 +842,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData(data || window.advocate_things_data);
+        var dataPrep = AT._prepareData(data || window[GLOBAL_DATA]);
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {
@@ -889,13 +890,13 @@
      */
 
     /**
-     * Automatically sends window.advocate_things_data as a touchpoint or
+     * Automatically sends window[GLOBAL_DATA] as a touchpoint or
      * sharepoint (if specified, else both).
      * @param {function} cb - Callback function.
      */
     requireKey._autoSend = function () {
         AT._log('info', '_autoSend()');
-        var data = window.advocate_things_data;
+        var data = window[GLOBAL_DATA];
 
         if (config.autoSend === 'touch') {
             return AT.registerTouch(null, data);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -591,7 +591,7 @@
 
         var token;
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
 
         if (name) {
             dataPrep._at.sharepointName = name;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -768,7 +768,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData({});
+        var dataPrep = AT._prepareData({}); // this is only used for the api key
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -572,7 +572,8 @@
         AT._log('info', 'createToken()');
 
         // Let's work out what's what
-        if (typeof name === 'object') {
+        //if (typeof name === 'object') {
+        if (Object.prototype.toString.call(name) === '[object Object]') {
             cb = data;
             data = name;
             name = null;
@@ -646,7 +647,7 @@
         AT._log('info', 'updateToken()');
 
         // Let's work out what's what
-        if (typeof name === 'object') {
+        if (Object.prototype.toString.call(token) === '[object Object]') {
             cb = data;
             data = token;
             token = null;

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -788,6 +788,29 @@
      * @param {function} [cb] - Callback function with (err, tokens).
      */
     requireKey.consumeToken = function (token, data, cb) {
+        // Let's work out what's what
+        if (Object.prototype.toString.call(token) === '[object Object]') {
+            cb = data;
+            data = token;
+            token = null;
+        }
+
+        if (typeof token === 'function') {
+            cb = token;
+            token = null;
+            data = null;
+        }
+
+        if (typeof data === 'function') {
+            cb = data;
+            data = null;
+        }
+
+        if (!token) {
+            // If no token defined, assume we want the first.
+            token = AT._getShareTokens()[0];
+        }
+
         if (!token) {
             if (cb) {
                 return cb(new Error('[consumeToken] You must specify a token to consume.'));
@@ -798,7 +821,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -546,7 +546,7 @@
 
         xhr.onload = function () {
             // Handle error responses.
-            if (!/^20[0-9]{1}/.test(xhr.status)) {
+            if (!/^200$/.test(xhr.status)) {
                 if (cb) {
                     return cb(new Error(xhr.statusText));
                 }
@@ -559,7 +559,7 @@
 
             AT._storeTouchpointData(res);
 
-            var meta = res.metadata;
+            var meta = JSON.parse(res.metadata);
 
             // Trigger saved event
             AT._triggerEvent(AT.Events.TouchRegistered, meta);

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -203,10 +203,6 @@
      * // TODO: fix
      */
     AT._getTouchpointShareTokens = function () {
-        if (!store.hasItem(STORAGE_NAME)) {
-            return [];
-        }
-
         var storeData = JSON.parse(store.getItem(STORAGE_NAME));
 
         var apiKey = config.apiKey;
@@ -266,6 +262,8 @@
      *                    available) or cookie storage.
      */
     AT._initStorage = function () {
+        var store = AT._utils.cookieStorage;
+
         if (window.localStorage) {
             // Test localStorage to see if we can use it
             var test = 'test';
@@ -273,15 +271,23 @@
                 AT._utils.lclStorage.setItem(test, test);
                 AT._utils.lclStorage.removeItem(test);
 
-                return AT._utils.lclStorage;
+                store = AT._utils.lclStorage;
             } catch (e) {
                 AT._log('warn', 'Failed to initialise localStorage, falling back to cookies');
             }
         }
 
-        return AT._utils.cookieStorage; // fall back to cookie storage
+        // Initialise if needed
+        if (!store.hasItem(STORAGE_NAME)) {
+            store.setItem(STORAGE_NAME, JSON.stringify({}), Infinity);
+        }
+
+        return store;
     };
 
+    /**
+     *
+     */
     AT._initSessionStorage = function () {
         var store = AT._utils.cookieStorage;
 
@@ -380,11 +386,6 @@
         //         -> data {})
         if (!data || Object.prototype.toString.call(data) !== '[object Object]' || !data.token) {
             return;
-        }
-
-        // TODO: this should be in init storage
-        if (!store.hasItem(STORAGE_NAME)) {
-            store.setItem(STORAGE_NAME, JSON.stringify({}), Infinity);
         }
 
         var currentlyStoredData = JSON.parse(store.getItem(STORAGE_NAME)); // TODO: try/catch
@@ -608,8 +609,6 @@
             cb = data;
             data = null;
         }
-
-        var token; // TODO: is this used?
 
         var dataPrep = AT._prepareData(data || window.advocate_things_data);
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -869,7 +869,7 @@
         xhr.send(dataString);
     };
 
-    // Convenience method
+    // Convenience methods
     AT.getAddressBarShareToken = function () {
         var tokens = AT.shareTokens;
         for (var i=0,len=tokens.length; i<len; i++) {
@@ -877,6 +877,10 @@
                 return AT._getAliasOrToken(tokens[i]);
             }
         }
+    };
+
+    AT.getDefaultToken = function () {
+        return AT._getShareTokens()[0] || null;
     };
 
     /**

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -288,7 +288,10 @@
     };
 
     /**
-     *
+     * Determines which type of browser storage to use. Will try session storage
+     * then fallback to cookie storage if it is not available.
+     * @return {object} - a uniform interface to access session storage (if
+     *                    available) or cookie storage.
      */
     AT._initSessionStorage = function () {
         var store = AT._utils.cookieStorage;
@@ -307,7 +310,7 @@
 
         // Initialise if needed
         if (!store.hasItem(SESSION_STORAGE_NAME)) {
-            store.setItem(STORAGE_NAME, JSON.stringify({}), Infinity);
+            store.setItem(SESSION_STORAGE_NAME, JSON.stringify({}), Infinity);
         }
 
         return store;

--- a/test/unit/_appendTokenToUrl.js
+++ b/test/unit/_appendTokenToUrl.js
@@ -7,6 +7,8 @@ var registerTouchStub;
 var historyReplaceStateStub;
 var regexpSpy;
 
+var pageTitle = 'Page Title';
+
 describe('_appendTokenToUrl()', function () {
 
     beforeEach(function () {
@@ -17,6 +19,8 @@ describe('_appendTokenToUrl()', function () {
         this.xhr.onCreate = function (xhr) {
             requests.push(xhr);
         };
+
+        document.title = pageTitle;
 
         AT.init({
             apiKey: 'foo',
@@ -64,7 +68,7 @@ describe('_appendTokenToUrl()', function () {
         var params = historyReplaceStateStub.args[0][2];
 
         expect(historyReplaceStateStub.calledOnce).to.be(true);
-        expect(title).to.be(null);
+        expect(title).to.be(pageTitle);
         expect(params).to.be('?bar=foo');
     });
 
@@ -81,7 +85,7 @@ describe('_appendTokenToUrl()', function () {
         var params = historyReplaceStateStub.args[0][2];
 
         expect(historyReplaceStateStub.calledOnce).to.be(true);
-        expect(title).to.be(null);
+        expect(title).to.be(pageTitle);
         expect(params).to.be('?bar=foo');
     });
 
@@ -97,7 +101,7 @@ describe('_appendTokenToUrl()', function () {
         var params = historyReplaceStateStub.args[0][2];
 
         expect(historyReplaceStateStub.calledOnce).to.be(true);
-        expect(title).to.be(null);
+        expect(title).to.be(pageTitle);
         expect(params).to.be('?bar=foo');
     });
 });

--- a/test/unit/_getShareTokens.js
+++ b/test/unit/_getShareTokens.js
@@ -1,0 +1,69 @@
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+var apiKey = 'foo';
+
+describe.only('_getShareTokens()', function () {
+
+    beforeEach(function () {
+	sinon.sandbox.create();
+
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        var requests = this.requests = [];
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+
+        AT.init({
+            apiKey: apiKey,
+            autoSend: false
+        });
+    });
+
+    afterEach(function () {
+        sinon.sandbox.restore();
+
+        this.xhr.restore();
+    });
+
+    it('should have a _getShareTokens function', function () {
+        expect(AT._getShareTokens).to.be.a('function');
+    });
+
+    it('should return an empty array if there are no tokens stored for the current api key', function () {
+        var fakeStore = {
+            getItem: function () {
+                var data = {
+                    wrongapikey: [ 'foo', 'bar', 'baz' ]
+                };
+
+                return JSON.stringify(data);
+            }
+        };
+
+        var _initSessionStorageStub = sinon.sandbox.stub(window.AT, '_initSessionStorage');
+        _initSessionStorageStub.returns(fakeStore);
+        AT._autoInit();
+
+        expect(AT._getShareTokens()).to.eql([]);
+    });
+
+    it('should return an array of tokens when there are tokens stored for the current api key', function () {
+        var fakeStore = {
+            getItem: function () {
+                var data = {
+                    wrongapikey: [ 'foo', 'bar', 'baz' ]
+                };
+                data[apiKey] = [ 'one', 'two' ];
+
+                return JSON.stringify(data);
+            }
+        };
+
+        var _initSessionStorageStub = sinon.sandbox.stub(window.AT, '_initSessionStorage');
+        _initSessionStorageStub.returns(fakeStore);
+        AT._autoInit();
+
+        expect(AT._getShareTokens()).to.eql([ 'one', 'two' ]);
+    });
+});

--- a/test/unit/_getShareTokens.js
+++ b/test/unit/_getShareTokens.js
@@ -3,7 +3,7 @@ var sinon = require('sinon');
 
 var apiKey = 'foo';
 
-describe.only('_getShareTokens()', function () {
+describe('_getShareTokens()', function () {
 
     beforeEach(function () {
 	sinon.sandbox.create();

--- a/test/unit/_getTouchpointShareTokens.js
+++ b/test/unit/_getTouchpointShareTokens.js
@@ -66,7 +66,7 @@ describe('_getTouchpointShareTokens()', function () {
         expect(AT._getTouchpointShareTokens).to.be.a('function');
     });
 
-    it('should return an empty array if there is no advocate things storage', function () {
+    xit('should return an empty array if there is no advocate things storage', function () {
         _initStorageStub = sinon.sandbox.stub(window.AT, '_initStorage');
         _initStorageStub.returns(storeNotExists);
         AT._autoInit();

--- a/test/unit/_getTouchpointShareTokens.js
+++ b/test/unit/_getTouchpointShareTokens.js
@@ -44,7 +44,7 @@ var storeFull = {
     }
 };
 
-describe('_getShareTokens()', function () {
+describe('_getTouchpointShareTokens()', function () {
 
     beforeEach(function () {
 	sinon.sandbox.create();
@@ -62,8 +62,8 @@ describe('_getShareTokens()', function () {
         this.xhr.restore();
     });
 
-    it('should have a _getShareTokens function', function () {
-        expect(AT._getShareTokens).to.be.a('function');
+    it('should have a _getTouchpointShareTokens function', function () {
+        expect(AT._getTouchpointShareTokens).to.be.a('function');
     });
 
     it('should return an empty array if there is no advocate things storage', function () {
@@ -76,7 +76,7 @@ describe('_getShareTokens()', function () {
             autoSend: false
         });
 
-	expect(AT._getShareTokens()).to.eql([]);
+	expect(AT._getTouchpointShareTokens()).to.eql([]);
     });
 
     it('should return an empty array if the advocate things storage is empty', function () {
@@ -89,7 +89,7 @@ describe('_getShareTokens()', function () {
             autoSend: false
         });
 
-	expect(AT._getShareTokens()).to.eql([]);
+	expect(AT._getTouchpointShareTokens()).to.eql([]);
     });
 
     it('should return an empty array if there are no stored objects for a client api key', function () {
@@ -102,7 +102,7 @@ describe('_getShareTokens()', function () {
             autoSend: false
         });
 
-        expect(AT._getShareTokens()).to.eql([]);
+        expect(AT._getTouchpointShareTokens()).to.eql([]);
     });
 
     it('should return an array of tokens for the provided client api key', function () {
@@ -115,7 +115,7 @@ describe('_getShareTokens()', function () {
             autoSend: false
         });
 
-        expect(AT._getShareTokens()).to.eql([
+        expect(AT._getTouchpointShareTokens()).to.eql([
             'token1',
             'token2'
         ]);

--- a/test/unit/_initSessionStorage.js
+++ b/test/unit/_initSessionStorage.js
@@ -1,8 +1,6 @@
 var expect = require('expect.js');
 var sinon = require('sinon');
 
-var defaultSessionStorageName = 'advocate-things';
-
 describe('_initSessionStorage()', function () {
 
     beforeEach(function () {

--- a/test/unit/_initSessionStorage.js
+++ b/test/unit/_initSessionStorage.js
@@ -1,6 +1,8 @@
 var expect = require('expect.js');
 var sinon = require('sinon');
 
+var sessionStorageName = 'advocate-things-session';
+
 describe('_initSessionStorage()', function () {
 
     beforeEach(function () {
@@ -79,6 +81,7 @@ describe('_initSessionStorage()', function () {
         AT._initSessionStorage();
 
         expect(setItemSpy.calledOnce).to.be(true);
+        expect(setItemSpy.args[0][0]).to.equal(sessionStorageName);
         expect(setItemSpy.args[0][1]).to.equal(JSON.stringify({}));
 
         // Revert

--- a/test/unit/_initSessionStorage.js
+++ b/test/unit/_initSessionStorage.js
@@ -1,0 +1,90 @@
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+var defaultSessionStorageName = 'advocate-things';
+
+describe('_initSessionStorage()', function () {
+
+    beforeEach(function () {
+	sinon.sandbox.create();
+
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        var requests = this.requests = [];
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+
+        AT.init({
+            apiKey: 'foo',
+            autoSend: false
+        });
+    });
+
+    afterEach(function () {
+        sinon.sandbox.restore();
+
+        this.xhr.restore();
+    });
+
+    it('should have a _initSessionStorage function', function () {
+        expect(AT._initSessionStorage).to.be.a('function');
+    });
+
+    it('should return a store object', function () {
+	var store = AT._initSessionStorage();
+
+        expect(store).to.be.an('object');
+    });
+
+    it('should have a getItem function on the store object', function () {
+        var store = AT._initSessionStorage();
+
+	expect(store.getItem).to.be.a('function');
+    });
+
+    it('should have a setItem function on the store object', function () {
+        var store = AT._initSessionStorage();
+
+        expect(store.setItem).to.be.a('function');
+    });
+
+    it('should have a hasItem function on the store object', function () {
+        var store = AT._initSessionStorage();
+
+        expect(store.hasItem).to.be.a('function');
+    });
+
+    it('should have a removeItem function on the store object', function () {
+        var store = AT._initSessionStorage();
+
+        expect(store.removeItem).to.be.a('function');
+    });
+
+    it('should initialise the storage if it is uninitialised', function () {
+        var origCookieStorage = AT._utils.cookieStorage;
+        var origSesStorage = AT._utils.sesStorage;
+
+        var setItemSpy = sinon.sandbox.spy();
+        AT._utils.cookieStorage = AT._utils.sesStorage = {
+            hasItem: function () {
+                return false;
+            },
+            setItem: function (storeName, toStore) {
+                if (storeName === 'test') {
+                    return;
+                }
+
+                return setItemSpy(storeName, toStore);
+            }
+        };
+
+        AT._initSessionStorage();
+
+        expect(setItemSpy.calledOnce).to.be(true);
+        expect(setItemSpy.args[0][1]).to.equal(JSON.stringify({}));
+
+        // Revert
+        AT._utils.cookieStorage = origCookieStorage;
+        AT._utils.sesStorage = origSesStorage;
+    });
+});

--- a/test/unit/_initStorage.js
+++ b/test/unit/_initStorage.js
@@ -57,4 +57,32 @@ describe('_initStorage()', function () {
 
         expect(store.removeItem).to.be.a('function');
     });
+
+    it('should initialise the storage if it is uninitialised', function () {
+        var origCookieStorage = AT._utils.cookieStorage;
+        var origSesStorage = AT._utils.sesStorage;
+
+        var setItemSpy = sinon.sandbox.spy();
+        AT._utils.cookieStorage = AT._utils.lclStorage = {
+            hasItem: function () {
+                return false;
+            },
+            setItem: function (storeName, toStore) {
+                if (storeName === 'test') {
+                    return;
+                }
+
+                return setItemSpy(storeName, toStore);
+            }
+        };
+
+        AT._initStorage();
+
+        expect(setItemSpy.calledOnce).to.be(true);
+        expect(setItemSpy.args[0][1]).to.equal(JSON.stringify({}));
+
+        // Revert
+        AT._utils.cookieStorage = origCookieStorage;
+        AT._utils.sesStorage = origSesStorage;
+    });
 });

--- a/test/unit/_initStorage.js
+++ b/test/unit/_initStorage.js
@@ -1,6 +1,8 @@
 var expect = require('expect.js');
 var sinon = require('sinon');
 
+var storageName = 'advocate-things';
+
 describe('_initStorage()', function () {
 
     beforeEach(function () {
@@ -60,7 +62,7 @@ describe('_initStorage()', function () {
 
     it('should initialise the storage if it is uninitialised', function () {
         var origCookieStorage = AT._utils.cookieStorage;
-        var origSesStorage = AT._utils.sesStorage;
+        var origLclStorage = AT._utils.lclStorage;
 
         var setItemSpy = sinon.sandbox.spy();
         AT._utils.cookieStorage = AT._utils.lclStorage = {
@@ -79,10 +81,11 @@ describe('_initStorage()', function () {
         AT._initStorage();
 
         expect(setItemSpy.calledOnce).to.be(true);
+        expect(setItemSpy.args[0][0]).to.equal(storageName);
         expect(setItemSpy.args[0][1]).to.equal(JSON.stringify({}));
 
         // Revert
         AT._utils.cookieStorage = origCookieStorage;
-        AT._utils.sesStorage = origSesStorage;
+        AT._utils.lclStorage = origLclStorage;
     });
 });

--- a/test/unit/_storeShareTokens.js
+++ b/test/unit/_storeShareTokens.js
@@ -2,7 +2,7 @@ var expect = require('expect.js');
 var sinon = require('sinon');
 
 var apiKey = 'foobarbaz';
-var defaultStorageName = 'advocate-things';
+var defaultSessionStorageName = 'advocate-things-session';
 
 describe('_storeShareTokens()', function () {
 
@@ -52,7 +52,7 @@ describe('_storeShareTokens()', function () {
                     anotherApiKey: [
                         'one', 'two', 'three'
                     ]
-                }
+                };
                 stored[apiKey] = [
                     'foo', 'bar', 'baz'
                 ];
@@ -72,7 +72,7 @@ describe('_storeShareTokens()', function () {
 
         AT._storeShareTokens(tokenData);
 
-        expect(setItemSpy.args[0][0]).to.equal(defaultStorageName);
+        expect(setItemSpy.args[0][0]).to.equal(defaultSessionStorageName);
         var tokenArrayForApiKey = JSON.parse(setItemSpy.args[0][1])[apiKey];
         expect(tokenArrayForApiKey).to.eql(['foo','bar','baz']);
     });

--- a/test/unit/_storeShareTokens.js
+++ b/test/unit/_storeShareTokens.js
@@ -1,0 +1,79 @@
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+var apiKey = 'foobarbaz';
+var defaultStorageName = 'advocate-things';
+
+describe('_storeShareTokens()', function () {
+
+    beforeEach(function () {
+	sinon.sandbox.create();
+
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        var requests = this.requests = [];
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+
+        AT._autoInit();         // restore everything
+        AT.init({
+            apiKey: apiKey,
+            autoSend: false
+        });
+    });
+
+    afterEach(function () {
+        sinon.sandbox.restore();
+
+        this.xhr.restore();
+    });
+
+    it('should have a _storeShareTokens function', function () {
+        expect(AT._storeShareTokens).to.be.a('function');
+    });
+
+    it('should return immediately if the passed data is not an array', function () {
+        var jsonParseSpy = sinon.sandbox.spy(window.JSON, 'parse');
+
+	AT._storeShareTokens(null);
+        AT._storeShareTokens({});
+        AT._storeShareTokens('string');
+        AT._storeShareTokens(123);
+
+        expect(jsonParseSpy.called).to.be(false);
+    });
+
+    it('should store only the tokens from the passed object array', function () {
+        var setItemSpy = sinon.sandbox.spy();
+        var fakeStore = {
+            setItem: setItemSpy,
+            getItem: function () {
+                var stored = {
+                    anotherApiKey: [
+                        'one', 'two', 'three'
+                    ]
+                }
+                stored[apiKey] = [
+                    'foo', 'bar', 'baz'
+                ];
+
+                return JSON.stringify(stored);
+            }
+        };
+        var _initSessionStorageStub = sinon.sandbox.stub(window.AT, '_initSessionStorage');
+        _initSessionStorageStub.returns(fakeStore);
+        AT._autoInit();
+
+	var tokenData = [
+            { token: 'foo' },
+            { token: 'bar' },
+            { token: 'baz' }
+        ];
+
+        AT._storeShareTokens(tokenData);
+
+        expect(setItemSpy.args[0][0]).to.equal(defaultStorageName);
+        var tokenArrayForApiKey = JSON.parse(setItemSpy.args[0][1])[apiKey];
+        expect(tokenArrayForApiKey).to.eql(['foo','bar','baz']);
+    });
+});

--- a/test/unit/_storeTouchpointData.js
+++ b/test/unit/_storeTouchpointData.js
@@ -151,16 +151,4 @@ describe('_storeTouchpointData()', function () {
         // Assert
         expect(spy.called).to.be(false);
     });
-
-    it('should initialise the advocate-things storage item if it does not exist', function () {
-        var jsonParseSpy = sinon.sandbox.spy(window.JSON, 'parse');
-        AT._autoInit();
-        AT.init({
-            apiKey: 'foo',
-            autoSend: false
-        });
-
-        AT._storeTouchpointData({ token: 'foo' });
-        expect(jsonParseSpy.calledOnce).to.be(true);
-    });
 });

--- a/test/unit/addEventListener.js
+++ b/test/unit/addEventListener.js
@@ -90,4 +90,4 @@ describe('addEventListener()', function () {
         expect(spyTC.calledOnce).to.be(true);
         expect(spyTU.calledOnce).to.be(false);
     });
-})
+});

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -159,6 +159,47 @@ describe('consumeToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.consumeToken('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.consumeToken('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
     it('should return the token that was returned by the server (same one in args)', function () {
         // Arrange
         var token = { token: 'footoken' };

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -219,4 +219,25 @@ describe('consumeToken()', function () {
         expect(err).to.be(null);
         expect(res).to.eql(token.token);
     });
+
+    it('should return the token that was returned by the server (same one in session storage)', function () {
+        // Arrange
+        var token = 'abc123';
+        _getShareTokensStub.returns([token]);
+        var spy = sinon.sandbox.spy();
+
+        // Act
+        AT.consumeToken({ _at: { shareChannel: 'foo' } }, spy);
+        this.requests[0].respond(
+            200,
+            { 'Content-Type': 'application/json; charset=utf-8' },
+            JSON.stringify({ token: token })
+        );
+
+        // Assert
+        var err = spy.args[0][0];
+        var res = spy.args[0][1];
+        expect(err).to.be(null);
+        expect(res).to.eql(token);
+    });
 });

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -220,7 +220,7 @@ describe('consumeToken()', function () {
         expect(res).to.eql(token.token);
     });
 
-    it.only('should return the token that was returned by the server (same one in session storage)', function () {
+    it('should return the token that was returned by the server (same one in session storage)', function () {
         // Arrange
         var token = 'abc123';
         _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -4,7 +4,6 @@ var sinon = require('sinon');
 var _getShareTokens;
 
 describe('consumeToken()', function () {
-
     beforeEach(function () {
 	sinon.sandbox.create();
 
@@ -30,6 +29,137 @@ describe('consumeToken()', function () {
         expect(AT.consumeToken).to.be.a('function');
     });
 
+    it('should correctly identify arguments ()', function () {
+        // Arrange
+        var defToken = 'abc123';
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.consumeToken();
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // when data is null, use this
+        expect(this.requests[0].url).to.contain(defToken);
+
+        window.advocate_things_data = origWindowAdvocateThingsData; // restore
+    });
+
+    it('should correctly identify arguments (str)', function () {
+        // Arrange
+        var str = 'str123';
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.consumeToken(str);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (obj)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.consumeToken(obj);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(defToken);
+    });
+
+    it('should correctly identify arguments (func)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.consumeToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(defToken);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, obj)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.consumeToken(str, obj);
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(str);
+    });
+
+    it('should correctly identify arguments (str, func)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.consumeToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (obj, fun)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.consumeToken(obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(defToken);
+    });
+
     it('should correctly identify arguments (str, obj, fun)', function () {
         // Arrange
         var str = 'str123';
@@ -45,70 +175,6 @@ describe('consumeToken()', function () {
         expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
         expect(_prepareDataSpy.args[0][0]).to.eql(obj);
         expect(this.requests[0].url).to.contain(str);
-    });
-
-    it('should correctly identify arguments (obj, fun)', function () {
-        // Arrange
-        var obj = { obj: 'obj' };
-        var fun = sinon.sandbox.spy();
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.consumeToken(obj, fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
-        expect(this.requests[0].url).to.contain(token); // fallback token
-    });
-
-    it('should correctly identify arguments (fun)', function () {
-        // Arrange
-        var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.consumeToken(fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
-        expect(this.requests[0].url).to.contain(token); // fallback token
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
-    });
-
-    it('should correctly identify arguments (str, fun)', function () {
-        // Arrange
-        var str = 'str123';
-        var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.consumeToken(str, fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
-        expect(this.requests[0].url).to.contain(str); // fallback token
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
     it('should fail if no token is provided and no stored tokens are available - with cb', function () {

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -220,9 +220,10 @@ describe('consumeToken()', function () {
         expect(res).to.eql(token.token);
     });
 
-    it('should return the token that was returned by the server (same one in session storage)', function () {
+    it.only('should return the token that was returned by the server (same one in session storage)', function () {
         // Arrange
         var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
         _getShareTokensStub.returns([token]);
         var spy = sinon.sandbox.spy();
 

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -111,7 +111,11 @@ describe('consumeToken()', function () {
         window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
-    it('should fail if no token is provided - with cb', function () {
+    it('should fail if no token is provided and no stored tokens are available - with cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.consumeToken(null, {}, function (err, res) {
             // Assert
@@ -120,6 +124,10 @@ describe('consumeToken()', function () {
     });
 
     it('should fail if no token is provided - no cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.consumeToken(null);
 
@@ -128,6 +136,10 @@ describe('consumeToken()', function () {
     });
 
     it('should fail if the token is an empty string - with cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.consumeToken('', function (err, res) {
             // Assert
@@ -136,6 +148,10 @@ describe('consumeToken()', function () {
     });
 
     it('should fail if the token is an empty string - no cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.consumeToken('');
 

--- a/test/unit/createToken.js
+++ b/test/unit/createToken.js
@@ -56,22 +56,40 @@ describe('createToken()', function () {
         // TODO: all assertions
     });
 
-    it('should fallback to using window.advocate_things_data if data is falsy', function () {
+     it('should use the specified data when it is provided', function () {
         // Arrange
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
         window.advocate_things_data = {
             _at: {
-                userId: '1234'
-            },
-            foo: {
-                bar: 'baz'
+                name: 'foo',
+                userId: 'id3'
             }
         };
-        var spy = sinon.sandbox.spy();
+        var data = { some: 'data' };
 
         // Act
-        AT.createToken('foo', null, spy);
+        AT.createToken('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.createToken('foo', null);
 
         // Assert
         expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);

--- a/test/unit/createToken.js
+++ b/test/unit/createToken.js
@@ -8,7 +8,7 @@ var _prepareDataSpy;
 
 var jsonStringifySpy;
 
-describe.only('createToken()', function () {
+describe('createToken()', function () {
 
     beforeEach(function () {
 	sinon.sandbox.create();

--- a/test/unit/createToken.js
+++ b/test/unit/createToken.js
@@ -56,6 +56,29 @@ describe('createToken()', function () {
         // TODO: all assertions
     });
 
+    it('should fallback to using window.advocate_things_data if data is falsy', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                userId: '1234'
+            },
+            foo: {
+                bar: 'baz'
+            }
+        };
+        var spy = sinon.sandbox.spy();
+
+        // Act
+        AT.createToken('foo', null, spy);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
     it('should return an error if the XHR fails - with cb', function () {
         // Arrange
         var spy = sinon.sandbox.spy();

--- a/test/unit/createToken.js
+++ b/test/unit/createToken.js
@@ -8,7 +8,7 @@ var _prepareDataSpy;
 
 var jsonStringifySpy;
 
-describe('createToken()', function () {
+describe.only('createToken()', function () {
 
     beforeEach(function () {
 	sinon.sandbox.create();
@@ -35,28 +35,135 @@ describe('createToken()', function () {
 	expect(AT.createToken).to.be.a('function');
     });
 
-    it('should correctly identify arguments (str, obj, fun)', function () {
-        var str = 'str';
-        var obj = { obj: 'obj' };
-        var fun = sinon.sandbox.spy();
+    it('should correctly identify arguments ()', function () {
+        // Arrange
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
 
+        // Act
+        AT.createToken();
+        this.requests[0].respond(400);
 
-	AT.createToken(str, obj, fun);
-        this.requests[0].respond(400); // quickest route to finish
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        // TODO: assertions for name and obj.
+        // Assert
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(undefined);
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // when data is null, use this
 
-        AT.createToken(obj, fun);
-        // TODO: all assertions
-
-        AT.createToken(fun);
-        // TODO: all assertions
-
-        AT.createToken(str, fun);
-        // TODO: all assertions
+        window.advocate_things_data = origWindowAdvocateThingsData; // restore
     });
 
-     it('should use the specified data when it is provided', function () {
+    it('should correctly identify arguments (str)', function () {
+        // Arrange
+        var str = 'str123';
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(str);
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(JSON.parse(this.requests[0].requestBody)._at.sharepointName).to.equal(str);
+    });
+
+    it('should correctly identify arguments (obj)', function () {
+        // Arrange
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(obj);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+    });
+
+    it('should correctly identify arguments (func)', function () {
+        // Arrange
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, obj)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(str, obj);
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(JSON.parse(this.requests[0].requestBody)._at.sharepointName).to.equal(str);
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+    });
+
+    it('should correctly identify arguments (str, func)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(JSON.parse(this.requests[0].requestBody)._at.sharepointName).to.equal(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (obj, fun)', function () {
+        // Arrange
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.registerTouch(obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+    });
+
+    it('should correctly identify arguments (str, obj, fun)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.createToken(str, obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(JSON.parse(this.requests[0].requestBody)._at.sharepointName).to.equal(str);
+    });
+
+    it('should use the specified data when it is provided', function () {
         // Arrange
         var origWindowAdvocateThingsData = window.advocate_thing_data;
         var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');

--- a/test/unit/getDefaultToken.js
+++ b/test/unit/getDefaultToken.js
@@ -1,0 +1,46 @@
+var expect = require('expect.js');
+var sinon = require('sinon');
+
+var _getShareTokensStub;
+
+describe('getDefaultToken()', function () {
+
+    beforeEach(function () {
+	sinon.sandbox.create();
+
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        var requests = this.requests = [];
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+
+	_getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+
+        AT.init({
+            apiKey: 'foo',
+            autoSend: false
+        });
+    });
+
+    afterEach(function () {
+        sinon.sandbox.restore();
+
+        this.xhr.restore();
+    });
+
+    it('should have a getDefaultToken function', function () {
+        expect(AT.getDefaultToken).to.be.a('function');
+    });
+
+    it('should return null if there are no stored tokens', function () {
+        _getShareTokensStub.returns([]);
+
+        expect(AT.getDefaultToken()).to.equal(null);
+    });
+
+    it('should return the first share token in the share token array', function () {
+	_getShareTokensStub.returns([ 'foo', 'bar', 'baz' ]);
+
+        expect(AT.getDefaultToken()).to.equal('foo');
+    });
+});

--- a/test/unit/lockToken.js
+++ b/test/unit/lockToken.js
@@ -30,6 +30,62 @@ describe('lockToken()', function () {
         expect(AT.lockToken).to.be.a('function');
     });
 
+    it('should correctly identify arguments ()', function () {
+        // Arrange
+        var defToken = 'abc123';
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.lockToken();
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(this.requests[0].url).to.contain(defToken);
+    });
+
+    it('should correctly identify arguments (str)', function () {
+        // Arrange
+        var str = 'str123';
+
+        // Act
+        AT.lockToken(str);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(this.requests[0].url).to.contain(str);
+    });
+
+    it('should correctly identify arguments (func)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var fun = sinon.sandbox.spy();
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.lockToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(this.requests[0].url).to.contain(defToken);
+    });
+
+    it('should correctly identify arguments (str, func)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+
+        // Act
+        AT.lockToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(this.requests[0].url).to.contain(str);
+    });
+
     it('should correctly identify arguments (token, cb)', function () {
 	// Arrange
         var str = 'str123';

--- a/test/unit/lockToken.js
+++ b/test/unit/lockToken.js
@@ -1,6 +1,8 @@
 var expect = require('expect.js');
 var sinon = require('sinon');
 
+var _getShareTokensStub;
+
 describe('lockToken()', function () {
 
     beforeEach(function () {
@@ -28,7 +30,41 @@ describe('lockToken()', function () {
         expect(AT.lockToken).to.be.a('function');
     });
 
-    it('should fail if no token is provided - with cb', function () {
+    it('should correctly identify arguments (token, cb)', function () {
+	// Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+
+        // Act
+        AT.lockToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(this.requests[0].url).to.contain(str);
+    });
+
+    it('should correctly identify arguments (cb)', function () {
+        // Arrange
+        var fun = sinon.sandbox.spy();
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.lockToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(this.requests[0].url).to.contain(token); // fallback token
+    });
+
+    it('should fail if no token is provided and no stored tokens are available - with cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.lockToken(null, function (err, res) {
             // Assert
@@ -36,7 +72,11 @@ describe('lockToken()', function () {
         });
     });
 
-    it('should fail if no token is provided - no cb', function () {
+    it('should fail if no token is provided and no stored tokens are available - no cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.lockToken(null);
 
@@ -44,7 +84,11 @@ describe('lockToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
-    it('should fail if the token is an empty string - with cb', function () {
+    it('should fail if the token is an empty string and no stored tokens are available - with cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.lockToken('', function (err, res) {
             // Assert
@@ -52,7 +96,11 @@ describe('lockToken()', function () {
         });
     });
 
-    it('should fail if the token is an empty string - no cb', function () {
+    it('should fail if the token is an empty string and no stored tokens are available - no cb', function () {
+        // Arrange
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
+
         // Act
         AT.lockToken('');
 
@@ -60,7 +108,7 @@ describe('lockToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
-    xit('should return the token that was returned by the server (same one in args)', function () {
+    it('should return the token that was returned by the server (same one in args)', function () {
         // Arrange
         var token = { token: 'footoken' };
         var spy = sinon.sandbox.spy();
@@ -78,5 +126,27 @@ describe('lockToken()', function () {
         var res = spy.args[0][1];
         expect(err).to.be(null);
         expect(res).to.eql(token.token);
+    });
+
+    it('should return the token that was returned by the server (same one in window.advocate_things_data)', function () {
+        // Arrange
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+        var spy = sinon.sandbox.spy();
+
+        // Act
+        AT.lockToken(spy);
+        this.requests[0].respond(
+            200,
+            { 'Content-Type': 'application/json; charset=utf-8' },
+            JSON.stringify({ token: token })
+        );
+
+        // Assert
+        var err = spy.args[0][0];
+        var res = spy.args[0][1];
+        expect(err).to.be(null);
+        expect(res).to.eql(token);
     });
 });

--- a/test/unit/lockToken.js
+++ b/test/unit/lockToken.js
@@ -4,7 +4,6 @@ var sinon = require('sinon');
 var _getShareTokensStub;
 
 describe('lockToken()', function () {
-
     beforeEach(function () {
 	sinon.sandbox.create();
 

--- a/test/unit/registerTouch.js
+++ b/test/unit/registerTouch.js
@@ -156,4 +156,39 @@ describe('registerTouch()', function () {
 
         window.advocate_things_data = origWindowAdvocateThingsData;
     });
+
+    it('should trigger appropriate events with a JSON object, not a stringified object', function () {
+        // Arrange
+        var token = 'foobar';
+        var metadata = { user: { id: '1234', name: 'John Smith' } };
+        var metaString = JSON.stringify(metadata);
+
+        var spyTR = sinon.sandbox.spy();
+        var spyRP = sinon.sandbox.spy();
+
+        AT.addEventListener(AT.Events.TouchRegistered, function (meta) {
+            // Assert!
+            expect(meta).to.be.an('object');
+            expect(meta).to.eql(metadata);
+            spyTR();
+        });
+        AT.addEventListener(AT.Events.ReferredPerson, function (meta) {
+            // Assert!
+            expect(meta).to.be.an('object');
+            expect(meta).to.eql(metadata);
+            spyRP();
+        });
+
+        // Act
+	AT.registerTouch('foo', null);
+        this.requests[0].respond(
+            200,
+            { 'Content-Type': 'application/json; charset=utf-8' },
+            JSON.stringify({ token: token, metadata: metaString })
+        );
+
+        // Assert
+        expect(spyTR.calledOnce).to.be(true);
+        expect(spyRP.calledOnce).to.be(true);
+    });
 });

--- a/test/unit/registerTouch.js
+++ b/test/unit/registerTouch.js
@@ -28,11 +28,132 @@ describe('registerTouch()', function () {
         expect(AT.registerTouch).to.be.a('function');
     });
 
-    it('should return an error if the XHR fails - with cb', function () {
+    it('should correctly identify arguments (str, obj, fun)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.registerTouch(str, obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
+    });
+
+    it('should correctly identify arguments (obj, fun)', function () {
+        // Arrange
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.registerTouch(obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        // No URL to check for tp name as it is worked out by the DB.
+    });
+
+    it('should correctly identify arguments (fun)', function () {
+        // Arrange
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.registerTouch(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, fun)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.registerTouch(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    xit('should return an error if the XHR fails - with cb', function () {
 
     });
 
-    it('should return if the XHR fails - no cb', function () {
+    xit('should return if the XHR fails - no cb', function () {
 
+    });
+
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.registerTouch('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.registerTouch('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 });

--- a/test/unit/registerTouch.js
+++ b/test/unit/registerTouch.js
@@ -156,39 +156,4 @@ describe('registerTouch()', function () {
 
         window.advocate_things_data = origWindowAdvocateThingsData;
     });
-
-    it('should trigger appropriate events with a JSON object, not a stringified object', function () {
-        // Arrange
-        var token = 'foobar';
-        var metadata = { user: { id: '1234', name: 'John Smith' } };
-        var metaString = JSON.stringify(metadata);
-
-        var spyTR = sinon.sandbox.spy();
-        var spyRP = sinon.sandbox.spy();
-
-        AT.addEventListener(AT.Events.TouchRegistered, function (meta) {
-            // Assert!
-            expect(meta).to.be.an('object');
-            expect(meta).to.eql(metadata);
-            spyTR();
-        });
-        AT.addEventListener(AT.Events.ReferredPerson, function (meta) {
-            // Assert!
-            expect(meta).to.be.an('object');
-            expect(meta).to.eql(metadata);
-            spyRP();
-        });
-
-        // Act
-	AT.registerTouch('foo', null);
-        this.requests[0].respond(
-            200,
-            { 'Content-Type': 'application/json; charset=utf-8' },
-            JSON.stringify({ token: token, metadata: metaString })
-        );
-
-        // Assert
-        expect(spyTR.calledOnce).to.be(true);
-        expect(spyRP.calledOnce).to.be(true);
-    });
 });

--- a/test/unit/registerTouch.js
+++ b/test/unit/registerTouch.js
@@ -2,7 +2,6 @@ var expect = require('expect.js');
 var sinon = require('sinon');
 
 describe('registerTouch()', function () {
-
     beforeEach(function () {
 	sinon.sandbox.create();
 
@@ -28,21 +27,106 @@ describe('registerTouch()', function () {
         expect(AT.registerTouch).to.be.a('function');
     });
 
-    it('should correctly identify arguments (str, obj, fun)', function () {
+    it('should correctly identify arguments ()', function () {
+        // Arrange
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+
+        // Act
+        AT.registerTouch();
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(undefined);
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // when data is null, use this
+
+        window.advocate_things_data = origWindowAdvocateThingsData; // restore
+    });
+
+    it('should correctly identify arguments (str)', function () {
         // Arrange
         var str = 'str123';
-        var obj = { obj: 'obj' };
-        var fun = sinon.sandbox.spy();
         _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
 
         // Act
-        AT.registerTouch(str, obj, fun);
+        AT.registerTouch(str);
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
+    });
+
+    it('should correctly identify arguments (obj)', function () {
+        // Arrange
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.registerTouch(obj);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+    });
+
+    it('should correctly identify arguments (func)', function () {
+        // Arrange
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.registerTouch(fun);
         this.requests[0].respond(400); // quickest route to finish
 
         // Assert
         expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, obj)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.registerTouch(str, obj);
+        this.requests[0].respond(400);
+
+        // Assert
         expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+    });
+
+    it('should correctly identify arguments (str, func)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.registerTouch(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
     it('should correctly identify arguments (obj, fun)', function () {
@@ -64,48 +148,21 @@ describe('registerTouch()', function () {
         // No URL to check for tp name as it is worked out by the DB.
     });
 
-    it('should correctly identify arguments (fun)', function () {
-        // Arrange
-        var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.registerTouch(fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
-    });
-
-    it('should correctly identify arguments (str, fun)', function () {
+    it('should correctly identify arguments (str, obj, fun)', function () {
         // Arrange
         var str = 'str123';
+        var obj = { obj: 'obj' };
         var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
         _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
-        _getShareTokensStub.returns([token]);
 
         // Act
-        AT.registerTouch(str, fun);
+        AT.registerTouch(str, obj, fun);
         this.requests[0].respond(400); // quickest route to finish
 
         // Assert
         expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
         expect(JSON.parse(this.requests[0].requestBody)._at.touchpointName).to.equal(str);
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
     xit('should return an error if the XHR fails - with cb', function () {

--- a/test/unit/updateToken.js
+++ b/test/unit/updateToken.js
@@ -65,10 +65,16 @@ describe('updateToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
-    xit('should use the first stored token if no token is provided', function () {
+    it('should use the first stored token if no token is provided', function () {
+        // Arrange
+        var token = 'abc123';
+        _getShareTokensStub.returns([token]);
+
         // Act
         AT.updateToken(null, {});
 
+        // Assert
+        expect(this.requests[0].url).to.contain(token);
     });
 
     it('should fail if no data is provided when a token is provided - with cb', function () {

--- a/test/unit/updateToken.js
+++ b/test/unit/updateToken.js
@@ -2,11 +2,12 @@ var expect = require('expect.js');
 var sinon = require('sinon');
 
 var _getShareTokensStub;
+var _prepareDataSpy;
 
 describe('updateToken()', function () {
 
     beforeEach(function () {
-	sinon.sandbox.create();
+        sinon.sandbox.create();
 
         this.xhr = sinon.useFakeXMLHttpRequest();
         var requests = this.requests = [];
@@ -31,6 +32,108 @@ describe('updateToken()', function () {
 
     it('should have a updateToken function', function () {
         expect(AT.updateToken).to.be.a('function');
+    });
+
+
+    it('should correctly identify arguments (str, obj, fun)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.updateToken(str, obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(str);
+    });
+
+    it('should correctly identify arguments (obj, fun)', function () {
+        // Arrange
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.updateToken(obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(token); // fallback token
+    });
+
+    it('should correctly identify arguments (fun)', function () {
+        // Arrange
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.updateToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(token); // fallback token
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, fun)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var token = 'abc123';
+        _getShareTokensStub.returns([token]);
+
+        // Act
+        AT.updateToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(str); // fallback token
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data if data is falsy', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                userId: '1234'
+            },
+            foo: {
+                bar: 'baz'
+            }
+        };
+        var spy = sinon.sandbox.spy();
+
+        // Act
+        AT.updateToken('foo', null, spy);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
     it('should fail if no token is provided when storage is empty - with cb', function () {

--- a/test/unit/updateToken.js
+++ b/test/unit/updateToken.js
@@ -3,6 +3,7 @@ var sinon = require('sinon');
 
 var _getShareTokensStub;
 var _prepareDataSpy;
+var _getDefaultTokenStub;
 
 describe('updateToken()', function () {
 
@@ -34,6 +35,136 @@ describe('updateToken()', function () {
         expect(AT.updateToken).to.be.a('function');
     });
 
+    it('should correctly identify arguments ()', function () {
+        // Arrange
+        var defToken = 'abc123';
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.updateToken();
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // when data is null, use this
+        expect(this.requests[0].url).to.contain(defToken);
+
+        window.advocate_things_data = origWindowAdvocateThingsData; // restore
+    });
+
+    it('should correctly identify arguments (str)', function () {
+        // Arrange
+        var str = 'str123';
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.updateToken(str);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (obj)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.updateToken(obj);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(defToken);
+    });
+
+    it('should correctly identify arguments (func)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.updateToken(fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(defToken);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (str, obj)', function () {
+        // Arrange
+        var str = 'str123';
+        var obj = { obj: 'obj' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.updateToken(str, obj);
+        this.requests[0].respond(400);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(str);
+    });
+
+    it('should correctly identify arguments (str, func)', function () {
+        // Arrange
+        var str = 'str123';
+        var fun = sinon.sandbox.spy();
+        var origWindowAdvocateThingsData = window.advocate_things_data;
+        window.advocate_things_data = { foo: 'bar' };
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+
+        // Act
+        AT.updateToken(str, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
+        expect(this.requests[0].url).to.contain(str);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should correctly identify arguments (obj, fun)', function () {
+        // Arrange
+        var defToken = 'abc123';
+        var obj = { obj: 'obj' };
+        var fun = sinon.sandbox.spy();
+        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        _getDefaultTokenStub = sinon.sandbox.stub(window.AT, 'getDefaultToken');
+        _getDefaultTokenStub.returns(defToken);
+
+        // Act
+        AT.updateToken(obj, fun);
+        this.requests[0].respond(400); // quickest route to finish
+
+        // Assert
+        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
+        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
+        expect(this.requests[0].url).to.contain(defToken);
+    });
 
     it('should correctly identify arguments (str, obj, fun)', function () {
         // Arrange
@@ -50,67 +181,6 @@ describe('updateToken()', function () {
         expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
         expect(_prepareDataSpy.args[0][0]).to.eql(obj);
         expect(this.requests[0].url).to.contain(str);
-    });
-
-    it('should correctly identify arguments (obj, fun)', function () {
-        // Arrange
-        var obj = { obj: 'obj' };
-        var fun = sinon.sandbox.spy();
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.updateToken(obj, fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(obj);
-        expect(this.requests[0].url).to.contain(token); // fallback token
-    });
-
-    it('should correctly identify arguments (fun)', function () {
-        // Arrange
-        var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.updateToken(fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
-        expect(this.requests[0].url).to.contain(token); // fallback token
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
-    });
-
-    it('should correctly identify arguments (str, fun)', function () {
-        // Arrange
-        var str = 'str123';
-        var fun = sinon.sandbox.spy();
-        var origWindowAdvocateThingsData = window.advocate_things_data;
-        window.advocate_things_data = { foo: 'bar' };
-        _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
-        var token = 'abc123';
-        _getShareTokensStub.returns([token]);
-
-        // Act
-        AT.updateToken(str, fun);
-        this.requests[0].respond(400); // quickest route to finish
-
-        // Assert
-        expect(fun.calledOnce).to.be(true); // If this wasn't the case, typeof spy != function and would fail
-        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data); // fallback data
-        expect(this.requests[0].url).to.contain(str); // fallback token
-
-        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 
     it('should fail if no token is provided when storage is empty - with cb', function () {

--- a/test/unit/updateToken.js
+++ b/test/unit/updateToken.js
@@ -1,6 +1,8 @@
 var expect = require('expect.js');
 var sinon = require('sinon');
 
+var _getShareTokensStub;
+
 describe('updateToken()', function () {
 
     beforeEach(function () {
@@ -11,6 +13,9 @@ describe('updateToken()', function () {
         this.xhr.onCreate = function (xhr) {
             requests.push(xhr);
         };
+
+        _getShareTokensStub = sinon.sandbox.stub(window.AT, '_getShareTokens');
+        _getShareTokensStub.returns([]);
 
         AT.init({
             apiKey: 'foo',
@@ -28,7 +33,7 @@ describe('updateToken()', function () {
         expect(AT.updateToken).to.be.a('function');
     });
 
-    it('should fail if no token is provided - with cb', function () {
+    it('should fail if no token is provided when storage is empty - with cb', function () {
         // Act
         AT.updateToken(null, {}, function (err, res) {
             // Assert
@@ -36,7 +41,7 @@ describe('updateToken()', function () {
         });
     });
 
-    it('should fail if no token is provided - no cb', function () {
+    it('should fail if no token is provided when storage is empty - no cb', function () {
         // Act
         AT.updateToken(null, {});
 
@@ -44,7 +49,7 @@ describe('updateToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
-    it('should fail if the token is an empty string - with cb', function () {
+    it('should fail if the token is an empty string when storage is empty - with cb', function () {
         // Act
         AT.updateToken('', {}, function (err, res) {
             // Assert
@@ -52,9 +57,47 @@ describe('updateToken()', function () {
         });
     });
 
-    it('should fail if the token is an empty string - no cb', function () {
+    it('should fail if the token is an empty string whens storage is empty - no cb', function () {
         // Act
         AT.updateToken('', {});
+
+        // Assert
+        expect(this.requests.length).to.be(0);
+    });
+
+    xit('should use the first stored token if no token is provided', function () {
+        // Act
+        AT.updateToken(null, {});
+
+    });
+
+    it('should fail if no data is provided when a token is provided - with cb', function () {
+        // Act
+        AT.updateToken('foo', null, function (err) {
+            // Assert
+            expect(err.message).to.be('[updateToken] You must specify data to update with.');
+        });
+    });
+
+    it('should fail if no data is provided when a token is provided - no cb', function () {
+        // Act
+        AT.updateToken('foo');
+
+        // Assert
+        expect(this.requests.length).to.be(0);
+    });
+
+    it('should fail if no data is provided when no token is provided and storage is empty - with cb', function () {
+        // Act
+        AT.updateToken(null, null, function (err) {
+            // Assert
+            expect(err.message).to.be('[updateToken] You must specify data to update with.');
+        });
+    });
+
+    it('should fail if no data is provided when no token is provided and storage is not empty - no cb', function () {
+        // Act
+        AT.updateToken();
 
         // Assert
         expect(this.requests.length).to.be(0);


### PR DESCRIPTION
On `createToken` we now store the array of token data `[ { token: ...} ... ]` in session storage in addition to `AT.shareTokens`. This allows the possible scenario of:

* navigate to page A and create a token
* navigate to page B (*e.g.* logged in) and we want update that token without referring to it. Not a behaviour we should keep, but useful for now. This should be addresses by `updateAllTokens` when it is written.

`createToken`, `updateToken`, `consumeToken` and `registerTouch` will now fallback to using `window.advocate_things_data` if `data` is `undefined`.

On a side note, fixes #29.
Now fixes #58.