### PR TITLE
Default data instead of {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ AT.init({
 
 See [`init`](#api-init) for all initialisation options.
 
+The following functions may be manually passed new data, or `window.advocate_things_data` may be updated and the functions called without data. That is, the contents of `window.advocate_things_data` is the default data that is sent with any request.
+
 To manually register touch data, use the [`registerTouch`](#api-registertouch) function:
 
 ```js

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -7,6 +7,7 @@
     var store = null;
     var config = {};
     AT.shareToken = null;
+    AT.shareTokens = [];
     AT.queryParamName = null;
 
     // Constants

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -445,7 +445,7 @@
     requireKey.registerTouch = function (name, data, cb) {
         AT._log('info', 'registerTouch()');
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
 
         if (name) {
             dataPrep._at.touchpointName = name;
@@ -524,7 +524,7 @@
 
         var token;
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
 
         if (name) {
             dataPrep._at.sharepointName = name;
@@ -585,7 +585,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {
@@ -632,7 +632,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData({});
+        var dataPrep = AT._prepareData({}); // this is only used for the api key
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {
@@ -680,7 +680,7 @@
 
         var xhr = new XMLHttpRequest();
 
-        var dataPrep = AT._prepareData(data);
+        var dataPrep = AT._prepareData(data || window.advocate_things_data);
         var dataString = JSON.stringify(dataPrep);
 
         xhr.onload = function () {

--- a/test/unit/consumeToken.js
+++ b/test/unit/consumeToken.js
@@ -60,6 +60,47 @@ describe('consumeToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.consumeToken('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.consumeToken('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
     it('should return the token that was returned by the server (same one in args)', function () {
         // Arrange
         var token = { token: 'footoken' };

--- a/test/unit/createToken.js
+++ b/test/unit/createToken.js
@@ -56,6 +56,47 @@ describe('createToken()', function () {
         // TODO: all assertions
     });
 
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.createToken('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.createToken('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
     it('should return an error if the XHR fails - with cb', function () {
         // Arrange
         var spy = sinon.sandbox.spy();

--- a/test/unit/registerTouch.js
+++ b/test/unit/registerTouch.js
@@ -28,11 +28,52 @@ describe('registerTouch()', function () {
         expect(AT.registerTouch).to.be.a('function');
     });
 
-    it('should return an error if the XHR fails - with cb', function () {
+    xit('should return an error if the XHR fails - with cb', function () {
 
     });
 
-    it('should return if the XHR fails - no cb', function () {
+    xit('should return if the XHR fails - no cb', function () {
 
+    });
+
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.registerTouch('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.registerTouch('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
     });
 });

--- a/test/unit/updateToken.js
+++ b/test/unit/updateToken.js
@@ -60,6 +60,47 @@ describe('updateToken()', function () {
         expect(this.requests.length).to.be(0);
     });
 
+    it('should use the specified data when it is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+        var data = { some: 'data' };
+
+        // Act
+        AT.updateToken('foo', data);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
+    it('should fallback to using window.advocate_things_data when no data is provided', function () {
+        // Arrange
+        var origWindowAdvocateThingsData = window.advocate_thing_data;
+        var _prepareDataSpy = sinon.sandbox.spy(window.AT, '_prepareData');
+        window.advocate_things_data = {
+            _at: {
+                name: 'foo',
+                userId: 'id3'
+            }
+        };
+
+        // Act
+        AT.updateToken('foo', null);
+
+        // Assert
+        expect(_prepareDataSpy.args[0][0]).to.eql(window.advocate_things_data);
+
+        window.advocate_things_data = origWindowAdvocateThingsData;
+    });
+
     it('should return the token that was returned by the server (same one in args)', function () {
         // Arrange
         var token = { token: 'footoken' };


### PR DESCRIPTION
During the rewrite, the default data of `window.advocate_things_data` was not retained. This has been added back for `createToken`, `updateToken`, `consumeToken` and `registerTouch`. This is not the case for `lockToken` as the only data it needs to send is an api key.